### PR TITLE
Updated phase1 methods based on feedback

### DIFF
--- a/basic-services.Tests/basic-services.Tests.csproj
+++ b/basic-services.Tests/basic-services.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes:
* Updated methods to include both a synchronous and asynchronous version. 
* Modified Login and Refresh methods to return the access token and expiration date of the token. 
* Added support for ignoring server certificate errors upon client creation.

To run tests compile basic-services-dotnet/basic-services with 'dotnet build' then change directory to basic-services-dotnet/basic-services.Tests and run 'dotnet test'.