### PR TITLE
Basic services tests updates

### DIFF
--- a/MetasysServices.Tests/MetasysClientCultureTests.cs
+++ b/MetasysServices.Tests/MetasysClientCultureTests.cs
@@ -37,6 +37,11 @@ namespace Tests
             Assert.AreEqual(unsupported, client.Localize(Unsupported));
             Assert.AreEqual(priority, client.Localize(PriorityNone));
             Assert.AreEqual(array, client.Localize(Array));
+
+            Assert.AreEqual(reliable, MetasysClient.StaticLocalize(Reliable));
+            Assert.AreEqual(unsupported, MetasysClient.StaticLocalize(Unsupported));
+            Assert.AreEqual(priority, MetasysClient.StaticLocalize(PriorityNone));
+            Assert.AreEqual(array, MetasysClient.StaticLocalize(Array));
         }
 
         [TestCase("en-US", "Reliable", "Unsupported object type", "0 (No Priority)", "Array")]

--- a/MetasysServices.Tests/MetasysClientTests.cs
+++ b/MetasysServices.Tests/MetasysClientTests.cs
@@ -1319,6 +1319,32 @@ namespace Tests
         }
 
         [Test]
+        public void TestGetCommandsOneNumberNullValues()
+        {
+            string command1 = string.Concat("{\"$schema\": \"http://json-schema.org/schema#\",",
+                "\"commandId\": \"Adjust\",",
+                "\"title\": \"Adjust\",",
+                "\"type\": \"array\",",
+                "\"items\": [{",
+                    "\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": null,",
+                    "\"maximum\": null",
+                    "}],",
+                "\"minItems\": 1,",
+                "\"maxItems\": 1 }");
+            httpTest.RespondWith(string.Concat("[", command1, "]"));
+                
+            var commands = client.GetCommands(mockid);
+
+            httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands")
+                .WithVerb(HttpMethod.Get)
+                .Times(1);
+            Command expected = new Command(JToken.Parse(command1), testCulture);
+            Assert.AreEqual(expected, commands.ElementAt(0));
+        }
+
+        [Test]
         public void TestGetCommandsTwoEnumOneNumber()
         {
             string command1 = string.Concat("{\"$schema\": \"http://json-schema.org/schema#\",",

--- a/MetasysServices.Tests/MetasysClientTests.cs
+++ b/MetasysServices.Tests/MetasysClientTests.cs
@@ -1827,7 +1827,7 @@ namespace Tests
                     "\"items\": [", obj2, "],",
                     $"\"self\": \"https://hostname/api/V2/objects/{mockid2}/objects?page=1&pageSize=200&sort=name\"}}"));
 
-            var objects = client.GetObjects(mockid3, 2).ToList();
+            var objects = client.GetObjects(mockid3, 3).ToList();
 
             httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid3}/objects")
                 .WithVerb(HttpMethod.Get)
@@ -1856,6 +1856,15 @@ namespace Tests
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
             Assert.AreEqual(0, objects.Count());
+        }
+
+        [Test]
+        public void TestGetObjectsLevelLessThanOne()
+        {
+            var objects = client.GetObjects(mockid, 0);
+
+            httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}/objects");
+            Assert.IsNull(objects);
         }
 
         [Test]

--- a/MetasysServices.Tests/MetasysModelTests.cs
+++ b/MetasysServices.Tests/MetasysModelTests.cs
@@ -17,7 +17,7 @@ namespace Tests
         private static readonly CultureInfo testCulture = new CultureInfo("en-US");
  
         [Test]
-        public void TestAccessToken()
+        public void TestAccessTokenEqual()
         {
             string date = "2030-01-01T00:00:00Z";
             DateTime dateTime = DateTime.Parse(date).ToUniversalTime();
@@ -30,7 +30,7 @@ namespace Tests
         }
 
         [Test]
-        public void TestCommand()
+        public void TestCommandEqual()
         {
             string command = string.Concat("{\"$schema\": \"http://json-schema.org/schema#\",",
                 "\"commandId\": \"Release\",",
@@ -51,19 +51,35 @@ namespace Tests
                     "\"title\": \"Value\",",
                     "\"minimum\": -20.0,",
                     "\"maximum\": 120.0",
+                    "},",
+                    "{\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": null,",
+                    "\"maximum\": 120.0",
+                    "},",
+                    "{\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": -20.0,",
+                    "\"maximum\": null",
+                    "},",
+                    "{\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": null,",
+                    "\"maximum\": null",
                     "}],",
-                "\"minItems\": 3,",
-                "\"maxItems\": 3 }");
+                "\"minItems\": 6,",
+                "\"maxItems\": 6 }");
             string commandCopy = String.Copy(command);
             Command cmd = new Command(JToken.Parse(command), testCulture);
             Command cmdCopy = new Command(JToken.Parse(commandCopy), testCulture);
-
+            
             Assert.AreEqual(cmd.GetHashCode(), cmdCopy.GetHashCode());
             Assert.AreEqual(cmd, cmdCopy);
+            Assert.NotNull(cmd.ToString());
         }
 
         [Test]
-        public void TestMetasysObject()
+        public void TestMetasysObjectEqual()
         {
             string obj = string.Concat("{",
                 "\"id\": \"11111111-2222-3333-4444-555555555555\",",
@@ -88,10 +104,11 @@ namespace Tests
 
             Assert.AreEqual(metObj.GetHashCode(), metObjCopy.GetHashCode());
             Assert.AreEqual(metObj, metObjCopy);
+            Assert.NotNull(metObj.ToString());
         }
 
         [Test]
-        public void TestMetasysObjectType()
+        public void TestMetasysObjectTypeEqual()
         {
             MetasysObjectType type = new MetasysObjectType(185, "objectTypeEnumSet.n50Class", 
                 "NAE55-NIE59", testCulture);
@@ -102,7 +119,7 @@ namespace Tests
         }
 
         [Test]
-        public void TestVariantArray()
+        public void TestVariantArrayEqual()
         {
             Guid id = new Guid("11111111-2222-3333-4444-555555555555");
             Guid idCopy = new Guid("11111111-2222-3333-4444-555555555555");
@@ -114,24 +131,24 @@ namespace Tests
         }
 
         [Test]
-        public void TestVariant()
+        public void TestVariantEqual()
         {
             Guid id = new Guid("11111111-2222-3333-4444-555555555555");
             Guid idCopy = new Guid("11111111-2222-3333-4444-555555555555");
             string data = string.Concat("{ ",
-                "\"property\": \"stringvalue\",",
+                "\"value\": 23,",
                 "\"reliability\": \"", Reliable, "\",",
                 "\"priority\": \"", PriorityNone, "\"}");
             string dataCopy = String.Copy(data);
 
-            Variant v = new Variant(id, JToken.Parse(data), "attr", testCulture);
-            Variant vCopy = new Variant(idCopy, JToken.Parse(dataCopy), "attr", testCulture);
+            Variant v = new Variant(id, JToken.Parse(data), "presentValue", testCulture);
+            Variant vCopy = new Variant(idCopy, JToken.Parse(dataCopy), "presentValue", testCulture);
             Assert.AreEqual(v.GetHashCode(), vCopy.GetHashCode());
             Assert.AreEqual(v, vCopy);
         }
 
         [Test]
-        public void TestVariantMultiple()
+        public void TestVariantMultipleEqual()
         {
             Guid id = new Guid("11111111-2222-3333-4444-555555555555");
             Guid idCopy = new Guid("11111111-2222-3333-4444-555555555555");
@@ -141,10 +158,175 @@ namespace Tests
             List<Variant> vlistCopy = new List<Variant>() { vCopy };
 
             VariantMultiple vm = new VariantMultiple(id, vlist);
-            VariantMultiple vmCopy = new VariantMultiple(id, vlistCopy);
+            VariantMultiple vmCopy = new VariantMultiple(idCopy, vlistCopy);
             
             Assert.AreEqual(vm.GetHashCode(), vmCopy.GetHashCode());
             Assert.AreEqual(vm, vmCopy);
+        }
+
+        [Test]
+        public void TestAccessTokenDoesNotEqualToken()
+        {
+            string date = "2030-01-01T00:00:00Z";
+            DateTime dateTime1 = DateTime.Parse(date).ToUniversalTime();
+            DateTime dateTime2 = DateTime.Parse(date).ToUniversalTime();
+            var token1 = new AccessToken("Bearer faketoken", dateTime1);
+            var token2 = new AccessToken("Bearer faketokem", dateTime2);
+
+            Assert.AreNotEqual(token1.GetHashCode(), token2.GetHashCode());
+            Assert.AreNotEqual(token1, token2);
+        }
+
+        [Test]
+        public void TestAccessTokenDoesNotEqualTime()
+        {
+            string date1 = "2030-01-01T00:00:00Z";
+            string date2 = "2030-01-01T00:00:01Z";
+            DateTime dateTime1 = DateTime.Parse(date1).ToUniversalTime();
+            DateTime dateTime2 = DateTime.Parse(date2).ToUniversalTime();
+            var token1 = new AccessToken("Bearer faketoken", dateTime1);
+            var token2 = new AccessToken("Bearer faketoken", dateTime2);
+
+            Assert.AreNotEqual(token1.GetHashCode(), token2.GetHashCode());
+            Assert.AreNotEqual(token1, token2);
+        }
+
+        [Test]
+        public void TestCommandDoesNotEqualValue()
+        {
+            string command1 = string.Concat("{\"$schema\": \"http://json-schema.org/schema#\",",
+                "\"commandId\": \"Release\",",
+                "\"title\": \"Release\",",
+                "\"type\": \"array\",",
+                "\"items\": [{",
+                    "\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": 0,",
+                    "\"maximum\": 100",
+                    "}],",
+                "\"minItems\": 1,",
+                "\"maxItems\": 1 }");
+            string command2 = string.Concat("{\"$schema\": \"http://json-schema.org/schema#\",",
+                "\"commandId\": \"Release\",",
+                "\"title\": \"Release\",",
+                "\"type\": \"array\",",
+                "\"items\": [{",
+                    "\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": null,",
+                    "\"maximum\": null",
+                    "}],",
+                "\"minItems\": 1,",
+                "\"maxItems\": 1 }");
+            Command cmd1 = new Command(JToken.Parse(command1), testCulture);
+            Command cmd2 = new Command(JToken.Parse(command2), testCulture);
+            
+            Assert.AreNotEqual(cmd1.GetHashCode(), cmd2.GetHashCode());
+            Assert.AreNotEqual(cmd1, cmd2);
+            Assert.AreNotEqual(cmd2, cmd1);
+        }
+
+        [Test]
+        public void TestMetasysObjectDoesNotEqual()
+        {
+            string obj = string.Concat("{",
+                "\"id\": \"11111111-2222-3333-4444-555555555555\",",
+                "\"itemReference\": \"fully:qualified/reference\",",
+                "\"name\": \"name\",",
+                "\"description\": \"description\",",
+                "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"}");
+            string obj2 = string.Concat("{",
+                "\"id\": \"11111111-2222-3333-4444-555555555556\",",
+                "\"itemReference\": \"fully:qualified/reference2\",",
+                "\"name\": \"name2\",",
+                "\"description\": \"description2\",",
+                "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"}");
+            string obj3 = string.Concat("{",
+                "\"id\": \"11111111-2222-3333-4444-555555555557\",",
+                "\"itemReference\": \"fully:qualified/reference3\",",
+                "\"name\": \"name3\",",
+                "\"description\": \"description3\",",
+                "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"}");
+
+            MetasysObject child = new MetasysObject(JToken.Parse(obj3), null, testCulture);
+            MetasysObject child2 = new MetasysObject(JToken.Parse(obj3), null, testCulture);
+            List<MetasysObject> childlist = new List<MetasysObject>() { child };
+            List<MetasysObject> childlist2 = new List<MetasysObject>() { child2 };
+
+            MetasysObject metObj = new MetasysObject(JToken.Parse(obj), childlist, testCulture);
+            MetasysObject metObj2 = new MetasysObject(JToken.Parse(obj2), childlist2, testCulture);
+            MetasysObject metObj3 = new MetasysObject(JToken.Parse(obj), null, testCulture);
+            MetasysObject metObj4 = new MetasysObject(JToken.Parse(obj2), null, testCulture);
+
+            Assert.AreNotEqual(metObj.GetHashCode(), metObj2.GetHashCode());
+            Assert.AreNotEqual(metObj, metObj2);
+            Assert.AreNotEqual(metObj3.GetHashCode(), metObj4.GetHashCode());
+            Assert.AreNotEqual(metObj3, metObj4);
+        }
+
+        [Test]
+        public void TestMetasysObjectTypeDoesNotEqual()
+        {
+            MetasysObjectType type = new MetasysObjectType(185, "objectTypeEnumSet.n50Class", 
+                "NAE55-NIE59", testCulture);
+            MetasysObjectType type2 = new MetasysObjectType(195, "objectTypeEnumSet.fieldBusClass", 
+                "Field Bus MSTP", testCulture);
+            Assert.AreNotEqual(type.GetHashCode(), type2.GetHashCode());
+            Assert.AreNotEqual(type, type2);
+        }
+
+        [Test]
+        public void TestVariantArrayDoesNotEqual()
+        {
+            Guid id = new Guid("11111111-2222-3333-4444-555555555555");
+            Guid id2 = new Guid("11111111-2222-3333-4444-555555555555");
+
+            Variant v = new Variant(id, JArray.Parse("[ 0, 1, 2 ]"), "attr", testCulture);
+            Variant v2 = new Variant(id2, JArray.Parse("[ 0, 1, 3 ]"), "attr", testCulture);
+            Assert.AreNotEqual(v.GetHashCode(), v2.GetHashCode());
+            Assert.AreNotEqual(v, v2);
+        }
+
+        [Test]
+        public void TestVariantDoesNotEqual()
+        {
+            Guid id = new Guid("11111111-2222-3333-4444-555555555555");
+            string data = string.Concat("{ ",
+                "\"value\": 23,",
+                "\"reliability\": \"", Reliable, "\",",
+                "\"priority\": \"", PriorityNone, "\"}");
+            string data2 = string.Concat("{ ",
+                "\"value\": 23,",
+                "\"reliability\": \"", Reliable, "\"}");
+            string data3 = string.Concat("{ ",
+                "\"value\": 24,",
+                "\"reliability\": \"", Reliable, "\",",
+                "\"priority\": \"", PriorityNone, "\"}");
+
+            Variant v = new Variant(id, JToken.Parse(data), "presentValue", testCulture);
+            Variant v2 = new Variant(id, JToken.Parse(data2), "presentValue", testCulture);
+            Variant v3 = new Variant(id, JToken.Parse(data3), "presentValue", testCulture);
+            Assert.AreNotEqual(v.GetHashCode(), v2.GetHashCode());
+            Assert.AreNotEqual(v, v2);
+            Assert.AreNotEqual(v.GetHashCode(), v3.GetHashCode());
+            Assert.AreNotEqual(v, v3);
+        }
+
+        [Test]
+        public void TestVariantMultipleDoesNotEqual()
+        {
+            Guid id = new Guid("11111111-2222-3333-4444-555555555555");
+            Guid id2 = new Guid("11111111-2222-3333-4444-555555555555");
+            Variant v = new Variant(id, JToken.FromObject("stringvalue"), "attr", testCulture);
+            Variant v2 = new Variant(id2, JToken.FromObject("stringvalwe"), "attr", testCulture);
+            List<Variant> vlist = new List<Variant>() { v };
+            List<Variant> vlist2 = new List<Variant>() { v2 };
+
+            VariantMultiple vm = new VariantMultiple(id, vlist);
+            VariantMultiple vm2 = new VariantMultiple(id2, vlist2);
+            
+            Assert.AreNotEqual(vm.GetHashCode(), vm2.GetHashCode());
+            Assert.AreNotEqual(vm, vm2);
         }
     }
 }

--- a/MetasysServices.Tests/MetasysModelTests.cs
+++ b/MetasysServices.Tests/MetasysModelTests.cs
@@ -1,0 +1,150 @@
+using System;
+using NUnit.Framework;
+using JohnsonControls.Metasys.BasicServices;
+using System.Globalization;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace Tests
+{
+    public class MetasysModelTests
+    {
+        private const string Reliable = "reliabilityEnumSet.reliable";
+        private const string PriorityNone = "writePriorityEnumSet.priorityNone";
+        private const string Unsupported = "statusEnumSet.unsupportedObjectType";
+        private const string Array = "dataTypeEnumSet.arrayDataType";
+        private static readonly CultureInfo testCulture = new CultureInfo("en-US");
+ 
+        [Test]
+        public void TestAccessToken()
+        {
+            string date = "2030-01-01T00:00:00Z";
+            DateTime dateTime = DateTime.Parse(date).ToUniversalTime();
+            DateTime dateTimeCopy = DateTime.Parse(date).ToUniversalTime();
+            var token1 = new AccessToken("Bearer faketoken", dateTime);
+            var token2 = new AccessToken("Bearer faketoken", dateTimeCopy);
+
+            Assert.AreEqual(token1.GetHashCode(), token2.GetHashCode());
+            Assert.AreEqual(token1, token2);
+        }
+
+        [Test]
+        public void TestCommand()
+        {
+            string command = string.Concat("{\"$schema\": \"http://json-schema.org/schema#\",",
+                "\"commandId\": \"Release\",",
+                "\"title\": \"Release\",",
+                "\"type\": \"array\",",
+                "\"items\": [{",
+                    "\"oneOf\": [{",
+                        "\"const\": \"attributeEnumSet.presentValue\",",
+                        "\"title\": \"Present Value\"}]",
+                    "},",
+                    "{\"oneOf\": [{",
+                        "\"const\": \"writePriorityEnumSet.priorityNone\",",
+                        "\"title\": \"0 (No Priority)\"},",
+                        "{\"const\": \"writePriorityEnumSet.priorityManualEmergency\",",
+                        "\"title\": \"1 (Manual Life Safety)\"}],",
+                    "},",
+                    "{\"type\": \"number\",",
+                    "\"title\": \"Value\",",
+                    "\"minimum\": -20.0,",
+                    "\"maximum\": 120.0",
+                    "}],",
+                "\"minItems\": 3,",
+                "\"maxItems\": 3 }");
+            string commandCopy = String.Copy(command);
+            Command cmd = new Command(JToken.Parse(command), testCulture);
+            Command cmdCopy = new Command(JToken.Parse(commandCopy), testCulture);
+
+            Assert.AreEqual(cmd.GetHashCode(), cmdCopy.GetHashCode());
+            Assert.AreEqual(cmd, cmdCopy);
+        }
+
+        [Test]
+        public void TestMetasysObject()
+        {
+            string obj = string.Concat("{",
+                "\"id\": \"11111111-2222-3333-4444-555555555555\",",
+                "\"itemReference\": \"fully:qualified/reference\",",
+                "\"name\": \"name\",",
+                "\"description\": \"description\",",
+                "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"}");
+            string obj2 = string.Concat("{",
+                "\"id\": \"11111111-2222-3333-4444-555555555556\",",
+                "\"itemReference\": \"fully:qualified/reference2\",",
+                "\"name\": \"name2\",",
+                "\"description\": \"description2\",",
+                "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"}");
+            string objCopy = String.Copy(obj);
+            MetasysObject child = new MetasysObject(JToken.Parse(obj2), null, testCulture);
+            MetasysObject childCopy = new MetasysObject(JToken.Parse(obj2), null, testCulture);
+            List<MetasysObject> childlist = new List<MetasysObject>() { child };
+            List<MetasysObject> childlistCopy = new List<MetasysObject>() { childCopy };
+
+            MetasysObject metObj = new MetasysObject(JToken.Parse(obj), childlist, testCulture);
+            MetasysObject metObjCopy = new MetasysObject(JToken.Parse(objCopy), childlistCopy, testCulture);
+
+            Assert.AreEqual(metObj.GetHashCode(), metObjCopy.GetHashCode());
+            Assert.AreEqual(metObj, metObjCopy);
+        }
+
+        [Test]
+        public void TestMetasysObjectType()
+        {
+            MetasysObjectType type = new MetasysObjectType(185, "objectTypeEnumSet.n50Class", 
+                "NAE55-NIE59", testCulture);
+            MetasysObjectType typeCopy = new MetasysObjectType(185, "objectTypeEnumSet.n50Class", 
+                "NAE55-NIE59", testCulture);
+            Assert.AreEqual(type.GetHashCode(), typeCopy.GetHashCode());
+            Assert.AreEqual(type, typeCopy);
+        }
+
+        [Test]
+        public void TestVariantArray()
+        {
+            Guid id = new Guid("11111111-2222-3333-4444-555555555555");
+            Guid idCopy = new Guid("11111111-2222-3333-4444-555555555555");
+
+            Variant v = new Variant(id, JArray.Parse("[ 0, 1, 2 ]"), "attr", testCulture);
+            Variant vCopy = new Variant(idCopy, JArray.Parse("[ 0, 1, 2 ]"), "attr", testCulture);
+            Assert.AreEqual(v.GetHashCode(), vCopy.GetHashCode());
+            Assert.AreEqual(v, vCopy);
+        }
+
+        [Test]
+        public void TestVariant()
+        {
+            Guid id = new Guid("11111111-2222-3333-4444-555555555555");
+            Guid idCopy = new Guid("11111111-2222-3333-4444-555555555555");
+            string data = string.Concat("{ ",
+                "\"property\": \"stringvalue\",",
+                "\"reliability\": \"", Reliable, "\",",
+                "\"priority\": \"", PriorityNone, "\"}");
+            string dataCopy = String.Copy(data);
+
+            Variant v = new Variant(id, JToken.Parse(data), "attr", testCulture);
+            Variant vCopy = new Variant(idCopy, JToken.Parse(dataCopy), "attr", testCulture);
+            Assert.AreEqual(v.GetHashCode(), vCopy.GetHashCode());
+            Assert.AreEqual(v, vCopy);
+        }
+
+        [Test]
+        public void TestVariantMultiple()
+        {
+            Guid id = new Guid("11111111-2222-3333-4444-555555555555");
+            Guid idCopy = new Guid("11111111-2222-3333-4444-555555555555");
+            Variant v = new Variant(id, JToken.FromObject("stringvalue"), "attr", testCulture);
+            Variant vCopy = new Variant(idCopy, JToken.FromObject("stringvalue"), "attr", testCulture);
+            List<Variant> vlist = new List<Variant>() { v };
+            List<Variant> vlistCopy = new List<Variant>() { vCopy };
+
+            VariantMultiple vm = new VariantMultiple(id, vlist);
+            VariantMultiple vmCopy = new VariantMultiple(id, vlistCopy);
+            
+            Assert.AreEqual(vm.GetHashCode(), vmCopy.GetHashCode());
+            Assert.AreEqual(vm, vmCopy);
+        }
+    }
+}

--- a/MetasysServices/Exceptions/MetasysException.cs
+++ b/MetasysServices/Exceptions/MetasysException.cs
@@ -50,7 +50,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// Initializes a new instance of the MetasysHttpException class using the Flurl.Http.FlurlHttpException class.
         /// </summary>
         /// <param name="e">The Flurl.Http exception.</param>
-        public MetasysHttpException(FlurlHttpException e) : base(e.Message, e) { 
+        public MetasysHttpException(FlurlHttpException e) : base(e.Message, e.InnerException) { 
             this.Call = e.Call;
             this.ResponseBody = e.GetResponseStringAsync().GetAwaiter().GetResult();
         }

--- a/MetasysServices/Exceptions/MetasysException.cs
+++ b/MetasysServices/Exceptions/MetasysException.cs
@@ -187,6 +187,21 @@ namespace JohnsonControls.Metasys.BasicServices
     /// An exception that is thrown when a MetasysObject could not be created from a Http response.
     /// </summary>
     [System.Serializable]
+    public class MetasysCommandException : MetasysHttpParsingException
+    {
+        /// <summary>
+        /// Initializes a new instance of the MetasysObjectException.
+        /// </summary>
+        /// <param name="response">The Http response.</param>
+        /// <param name="inner">The inner exception.</param>
+        public MetasysCommandException(string response, Exception inner) :
+            base($"Could not create Command from response.", response, inner) { }
+    }
+
+    /// <summary>
+    /// An exception that is thrown when a MetasysObject could not be created from a Http response.
+    /// </summary>
+    [System.Serializable]
     public class MetasysObjectException : MetasysHttpParsingException
     {
         /// <summary>

--- a/MetasysServices/Exceptions/MetasysException.cs
+++ b/MetasysServices/Exceptions/MetasysException.cs
@@ -211,6 +211,13 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="inner">The inner exception.</param>
         public MetasysObjectException(string response, Exception inner) :
             base($"Could not create MetasysObject from response.", response, inner) { }
+
+        /// <summary>
+        /// Initializes a new instance of the MetasysObjectException.
+        /// </summary>
+        /// <param name="inner">The inner exception.</param>
+        public MetasysObjectException(Exception inner) :
+            base($"An error occurred while creating the MetasysObject.", inner) { }
     }
 
     /// <summary>

--- a/MetasysServices/Models/AccessToken.cs
+++ b/MetasysServices/Models/AccessToken.cs
@@ -19,5 +19,29 @@ namespace JohnsonControls.Metasys.BasicServices
             Token = token;
             Expires = expires;
         }
+        
+        /// <summary>
+        /// Returns a value indicating whither this instance has values equal to a specified object.
+        /// </summary>
+        /// <param name="obj"></param>
+        public override bool Equals(object obj)
+        {
+            if (obj != null && obj is AccessToken)
+            {
+                var other = (AccessToken)obj;
+                return (((this.Token == null && other.Token == null) || (this.Token != null && this.Token.Equals(other.Token))) &&
+                    other.Expires.Equals(this.Expires));
+            }
+            return false;
+        }
+
+        /// <summary></summary>
+        public override int GetHashCode()
+        {
+            var code = 13;
+            code = (code * 7) + Token.GetHashCode();
+            code = (code * 7) + Expires.GetHashCode();
+            return code;
+        }
     }
 }

--- a/MetasysServices/Models/AccessToken.cs
+++ b/MetasysServices/Models/AccessToken.cs
@@ -39,8 +39,10 @@ namespace JohnsonControls.Metasys.BasicServices
         public override int GetHashCode()
         {
             var code = 13;
-            code = (code * 7) + Token.GetHashCode();
-            code = (code * 7) + Expires.GetHashCode();
+            if (Token != null)
+                code = (code * 7) + Token.GetHashCode();
+            if (Expires != null)
+                code = (code * 7) + Expires.GetHashCode();
             return code;
         }
     }

--- a/MetasysServices/Models/Command.cs
+++ b/MetasysServices/Models/Command.cs
@@ -63,15 +63,15 @@ namespace JohnsonControls.Metasys.BasicServices
             /// The minimum value the number can be if a number.
             /// </summary>
             /// <value>The minimum value of the number or 1 if not a number.</value>
-            public double Minimum;
+            public double? Minimum;
 
             /// <summary>
             /// The maximum value the number can be if a number.
             /// </summary>
             /// <value>The maximum value of the number or 1 if not a number.</value>
-            public double Maximum;
+            public double? Maximum;
 
-            internal Item(string title, string type, double minimum = 1, double maximum = 1, IEnumerable<EnumerationItem> enums = null)
+            internal Item(string title, string type, double? minimum = 1, double? maximum = 1, IEnumerable<EnumerationItem> enums = null)
             {
                 Title = title;
                 Type = type;
@@ -91,8 +91,10 @@ namespace JohnsonControls.Metasys.BasicServices
                     var other = (Item)obj;
                     bool areEqual = (((this.Type == null && other.Type == null) || (this.Type != null && this.Type.Equals(other.Type))) &&
                         ((this.Title == null && other.Title == null) || (this.Title != null && this.Title.Equals(other.Title))) &&
-                        this.Maximum == other.Maximum &&
-                        this.Minimum == other.Minimum);
+                        ((this.Maximum == null && other.Maximum == null) || (this.Maximum != null && this.Maximum.Equals(other.Maximum))) &&
+                        ((this.Minimum == null && other.Minimum == null) || (this.Minimum != null && this.Minimum.Equals(other.Minimum))));
+                        // this.Maximum == other.Maximum &&
+                        // this.Minimum == other.Minimum);
                         
                     if (areEqual)
                     {
@@ -113,12 +115,24 @@ namespace JohnsonControls.Metasys.BasicServices
             /// <summary></summary>
             public override int GetHashCode()
             {
-                var code = 13;
-                code = (code * 7) + Type.GetHashCode();
-                code = (code * 7) + Title.GetHashCode();
-                code = (code * 7) + Maximum.GetHashCode();
-                code = (code * 7) + Minimum.GetHashCode();
-                code = (code * 7) + EnumerationValues.GetHashCode();
+                var code = 13 * 13;
+                if (Type != null)
+                    code = (code * 7) + Type.GetHashCode();
+                if (Title != null)
+                    code = (code * 7) + Title.GetHashCode();
+                if (Maximum != null)
+                    code = (code * 7) + Maximum.GetHashCode();
+                if (Minimum != null)
+                    code = (code * 7) + Minimum.GetHashCode();
+                if (EnumerationValues != null)
+                {
+                    var arrCode = 0;
+                    foreach(var item in EnumerationValues)
+                    {
+                        arrCode += item.GetHashCode();
+                    }
+                    code = (code * 7) + arrCode;
+                }
                 return code;
             }
         }
@@ -163,7 +177,9 @@ namespace JohnsonControls.Metasys.BasicServices
             /// <summary></summary>
             public override int GetHashCode()
             {
-                return TitleEnumerationKey.GetHashCode();
+                if (TitleEnumerationKey != null)
+                    return TitleEnumerationKey.GetHashCode();
+                return 17;
             }
         }
 
@@ -189,8 +205,13 @@ namespace JohnsonControls.Metasys.BasicServices
                     {
                         string iTitle = item["title"].Value<string>();
                         string type = item["type"].Value<string>();
-                        double maximum = item["maximum"].Value<double>();
-                        double minimum = item["minimum"].Value<double>();
+                        double? maximum = null;
+                        double? minimum = null;
+                        if (item["maximum"].Type != JTokenType.Null)
+                            maximum = item["maximum"].Value<double>();
+                        if (item["minimum"].Type != JTokenType.Null)
+                            minimum = item["minimum"].Value<double>();
+                        
                         itemsList.Add(new Item(iTitle, type, minimum, maximum));
                     }
                     else
@@ -284,8 +305,17 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             var code = 13;
             code = (code * 7) + CommandId.GetHashCode();
-            code = (code * 7) + TitleEnumerationKey.GetHashCode();
-            code = (code * 7) + Items.GetHashCode();
+            if (TitleEnumerationKey != null)
+                code = (code * 7) + TitleEnumerationKey.GetHashCode();
+            if (Items != null)
+            {
+                var arrCode = 0;
+                foreach(var item in Items)
+                {
+                    arrCode += item.GetHashCode();
+                }
+                code = (code * 7) + arrCode;
+            }
             return code;
         }
     }

--- a/MetasysServices/Models/Command.cs
+++ b/MetasysServices/Models/Command.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace JohnsonControls.Metasys.BasicServices
@@ -78,6 +79,48 @@ namespace JohnsonControls.Metasys.BasicServices
                 Maximum = maximum;
                 EnumerationValues = enums;
             }
+
+            /// <summary>
+            /// Returns a value indicating whither this instance has values equal to a specified object.
+            /// </summary>
+            /// <param name="obj"></param>
+            public override bool Equals(object obj)
+            {
+                if (obj != null && obj is Item)
+                {
+                    var other = (Item)obj;
+                    bool areEqual = (((this.Type == null && other.Type == null) || (this.Type != null && this.Type.Equals(other.Type))) &&
+                        ((this.Title == null && other.Title == null) || (this.Title != null && this.Title.Equals(other.Title))) &&
+                        this.Maximum == other.Maximum &&
+                        this.Minimum == other.Minimum);
+                        
+                    if (areEqual)
+                    {
+                        if (this.EnumerationValues == null ^ other.EnumerationValues == null)
+                        {
+                            return false;
+                        } 
+                        else if (this.EnumerationValues != null && other.EnumerationValues != null)
+                        {
+                            return Enumerable.SequenceEqual(this.EnumerationValues, other.EnumerationValues);
+                        }
+                    }
+                    return areEqual;                        
+                }
+                return false;
+            }
+
+            /// <summary></summary>
+            public override int GetHashCode()
+            {
+                var code = 13;
+                code = (code * 7) + Type.GetHashCode();
+                code = (code * 7) + Title.GetHashCode();
+                code = (code * 7) + Maximum.GetHashCode();
+                code = (code * 7) + Minimum.GetHashCode();
+                code = (code * 7) + EnumerationValues.GetHashCode();
+                return code;
+            }
         }
 
         /// <summary>
@@ -101,6 +144,26 @@ namespace JohnsonControls.Metasys.BasicServices
             {
                 Title = title;
                 TitleEnumerationKey = key;
+            }
+
+            /// <summary>
+            /// Returns a value indicating whither this instance has values equal to a specified object.
+            /// </summary>
+            /// <param name="obj"></param>
+            public override bool Equals(object obj)
+            {
+                if (obj != null && obj is EnumerationItem)
+                {
+                    var other = (EnumerationItem)obj;
+                    return this.TitleEnumerationKey.Equals(other.TitleEnumerationKey);
+                }
+                return false;
+            }
+
+            /// <summary></summary>
+            public override int GetHashCode()
+            {
+                return TitleEnumerationKey.GetHashCode();
             }
         }
 
@@ -187,6 +250,43 @@ namespace JohnsonControls.Metasys.BasicServices
                 str = string.Concat(str, "\n");
             }
             return str;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whither this instance has values equal to a specified object.
+        /// </summary>
+        /// <param name="obj"></param>
+        public override bool Equals(object obj)
+        {
+            if (obj != null && obj is Command)
+            {
+                var other = (Command)obj;
+                bool areEqual = this.CommandId.Equals(other.CommandId) && 
+                    this.TitleEnumerationKey.Equals(other.TitleEnumerationKey);
+                if (areEqual)
+                {
+                    if (this.Items == null ^ other.Items == null)
+                    {
+                        return false;
+                    } 
+                    else if (this.Items != null && other.Items != null)
+                    {
+                        return Enumerable.SequenceEqual(this.Items, other.Items);
+                    }
+                }
+                return areEqual;
+            }
+            return false;
+        }
+
+        /// <summary></summary>
+        public override int GetHashCode()
+        {
+            var code = 13;
+            code = (code * 7) + CommandId.GetHashCode();
+            code = (code * 7) + TitleEnumerationKey.GetHashCode();
+            code = (code * 7) + Items.GetHashCode();
+            return code;
         }
     }
 }

--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -110,10 +110,21 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             var code = 13;
             code = (code * 7) + Id.GetHashCode();
-            code = (code * 7) + ItemReference.GetHashCode();
-            code = (code * 7) + Description.GetHashCode();
+            if (ItemReference != null)
+                code = (code * 7) + ItemReference.GetHashCode();
+            if (Description != null)
+                code = (code * 7) + Description.GetHashCode();
             code = (code * 7) + ChildrenCount.GetHashCode();
-            code = (code * 7) + Children.GetHashCode();
+            if (Children != null)
+            {
+                var arrCode = 0;
+                foreach(var item in Children)
+                {
+                    arrCode += item.GetHashCode();
+                }
+                code = (code * 7) + arrCode;
+            }
+                
             return code;
         }
     }

--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -97,5 +97,49 @@ namespace JohnsonControls.Metasys.BasicServices
                 "Description: ", Description, "\n",
                 "Number of Children: ", ChildrenCount);
         }
+
+        /// <summary>
+        /// Returns a value indicating whither this instance has values equal to a specified object.
+        /// </summary>
+        /// <param name="obj"></param>
+        public override bool Equals(object obj)
+        {
+            if (obj != null && obj is MetasysObject)
+            {
+                var other = (MetasysObject)obj;
+                bool areEqual = ((this.Id == null && other.Id == null) || (this.Id != null && this.Id.Equals(other.Id))) &&
+                    ((this.ItemReference == null && other.ItemReference == null) || 
+                        (this.ItemReference != null && this.ItemReference.Equals(other.ItemReference))) &&
+                    ((this.Description == null && other.Description == null) || 
+                        (this.Description != null && this.Description.Equals(other.Description))) &&
+                    this.ChildrenCount == other.ChildrenCount;
+                    
+                if (areEqual)
+                {
+                    if (this.Children == null ^ other.Children == null)
+                    {
+                        return false;
+                    } 
+                    else if (this.Children != null && other.Children != null)
+                    {
+                        return Enumerable.SequenceEqual(this.Children, other.Children);
+                    }
+                }
+                return areEqual; 
+            }
+            return false;
+        }
+
+        /// <summary></summary>
+        public override int GetHashCode()
+        {
+            var code = 13;
+            code = (code * 7) + Id.GetHashCode();
+            code = (code * 7) + ItemReference.GetHashCode();
+            code = (code * 7) + Description.GetHashCode();
+            code = (code * 7) + ChildrenCount.GetHashCode();
+            code = (code * 7) + Children.GetHashCode();
+            return code;
+        }
     }
 }

--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Newtonsoft.Json.Linq;
@@ -50,39 +50,14 @@ namespace JohnsonControls.Metasys.BasicServices
             try
             {
                 Id = new Guid(token["id"].Value<string>());
-            }
-            catch
-            {
-                Id = Guid.Empty;
-            }
-
-            string placeholder = "";
-            try
-            {
                 ItemReference = token["itemReference"].Value<string>();
-            }
-            catch
-            {
-                ItemReference = placeholder;
-            }
-
-            try
-            {
                 Name = token["name"].Value<string>();
-            }
-            catch
-            {
-                Name = placeholder;
-            }
-
-            try
-            {
                 Description = token["description"].Value<string>();
             }
-            catch
+            catch (Exception e)
             {
-                Description = placeholder;
-            }
+                throw new MetasysObjectException(token.ToString(), e);
+            }   
         }
 
         /// <summary>

--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -47,17 +47,35 @@ namespace JohnsonControls.Metasys.BasicServices
                 ChildrenCount = -1;
             }
 
+            string placeholder = "NULL";
+
             try
             {
                 Id = new Guid(token["id"].Value<string>());
                 ItemReference = token["itemReference"].Value<string>();
-                Name = token["name"].Value<string>();
-                Description = token["description"].Value<string>();
             }
             catch (Exception e)
             {
                 throw new MetasysObjectException(token.ToString(), e);
-            }   
+            }
+
+            try
+            {
+                Name = token["name"].Value<string>();
+            }
+            catch
+            {
+                Name = placeholder;
+            }
+
+            try
+            {
+                Description = token["description"].Value<string>();
+            }
+            catch
+            {
+                Description = placeholder;
+            }
         }
 
         /// <summary>

--- a/MetasysServices/Models/MetasysObjectType.cs
+++ b/MetasysServices/Models/MetasysObjectType.cs
@@ -34,5 +34,31 @@ namespace JohnsonControls.Metasys.BasicServices
             Description = description;
             Id = id;
         }
+
+        /// <summary>
+        /// Returns a value indicating whither this instance has values equal to a specified object.
+        /// </summary>
+        /// <param name="obj"></param>
+        public override bool Equals(object obj)
+        {
+            if (obj != null && obj is MetasysObjectType)
+            {
+                var other = (MetasysObjectType)obj;
+                return this.Id.Equals(other.Id) &&
+                    ((this.DescriptionEnumerationKey == null && other.DescriptionEnumerationKey == null) || 
+                        (this.DescriptionEnumerationKey != null && 
+                            this.DescriptionEnumerationKey.Equals(other.DescriptionEnumerationKey)));
+            }
+            return false;
+        }
+
+        /// <summary></summary>
+        public override int GetHashCode()
+        {
+            var code = 13;
+            code = (code * 7) + Id.GetHashCode();
+            code = (code * 7) + DescriptionEnumerationKey.GetHashCode();
+            return code;
+        }
     }
 }

--- a/MetasysServices/Models/MetasysObjectType.cs
+++ b/MetasysServices/Models/MetasysObjectType.cs
@@ -57,7 +57,8 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             var code = 13;
             code = (code * 7) + Id.GetHashCode();
-            code = (code * 7) + DescriptionEnumerationKey.GetHashCode();
+            if (DescriptionEnumerationKey != null)
+                code = (code * 7) + DescriptionEnumerationKey.GetHashCode();
             return code;
         }
     }

--- a/MetasysServices/Models/Variant.cs
+++ b/MetasysServices/Models/Variant.cs
@@ -265,12 +265,16 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             var code = 13;
             code = (code * 7) + Id.GetHashCode();
-            code = (code * 7) + Attribute.GetHashCode();
+            if (Attribute != null)
+                code = (code * 7) + Attribute.GetHashCode();
             code = (code * 7) + NumericValue.GetHashCode();
-            code = (code * 7) + StringValueEnumerationKey.GetHashCode();
+            if (StringValueEnumerationKey != null)
+                code = (code * 7) + StringValueEnumerationKey.GetHashCode();
             code = (code * 7) + BooleanValue.GetHashCode();
-            code = (code * 7) + PriorityEnumerationKey.GetHashCode();
-            code = (code * 7) + ReliabilityEnumerationKey.GetHashCode();
+            if (PriorityEnumerationKey != null)
+                code = (code * 7) + PriorityEnumerationKey.GetHashCode();
+            if (ReliabilityEnumerationKey != null)
+                code = (code * 7) + ReliabilityEnumerationKey.GetHashCode();
             var arrCode = 13;
             if (ArrayValue != null)
             {

--- a/MetasysServices/Models/Variant.cs
+++ b/MetasysServices/Models/Variant.cs
@@ -70,7 +70,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// If the attribute is "presentValue": the reliability enumeration key of the reliability.
         /// Otherwise reliabilityEnumSet.reliable by default.
         /// </value>
-        public string ReliabilityEnumerationKey  { private set; get; }
+        public string ReliabilityEnumerationKey { private set; get; }
 
         /// <summary>The priority of the value.</summary>
         /// <value>
@@ -84,7 +84,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// If the attribute is "presentValue": the priority enumeration key of the priority.
         /// Otherwise null by default.
         /// </value>
-        public string PriorityEnumerationKey  { private set; get; }
+        public string PriorityEnumerationKey { private set; get; }
 
         /// <summary>Boolean representation of the reliability of the value.</summary>
         /// <value>True if the reliability of the value is reliable.</value>
@@ -211,6 +211,75 @@ namespace JohnsonControls.Metasys.BasicServices
             {
                 ProcessToken(null);
             }
+        }
+
+        /// <summary>
+        /// Returns a value indicating whither this instance has values equal to a specified object.
+        /// </summary>
+        /// <param name="obj"></param>
+        public override bool Equals(object obj)
+        {
+            if (obj != null && obj is Variant)
+            {
+                var other = (Variant)obj;
+                bool areEqual = (((this.Id == null && other.Id == null) ||
+                    (this.Id != null && this.Id.Equals(other.Id))) &&
+                    ((this.Attribute == null && other.Attribute == null) ||
+                        (this.Attribute != null && this.Attribute.Equals(other.Attribute))) &&
+                    (this.NumericValue == other.NumericValue) &&
+                    ((this.StringValueEnumerationKey == null && other.StringValueEnumerationKey == null) ||
+                        (this.StringValueEnumerationKey != null &&
+                            this.StringValueEnumerationKey.Equals(other.StringValueEnumerationKey))) &&
+                    (this.BooleanValue == other.BooleanValue) &&
+                    ((this.PriorityEnumerationKey == null && other.PriorityEnumerationKey == null) ||
+                        (this.PriorityEnumerationKey != null &&
+                            this.PriorityEnumerationKey.Equals(other.PriorityEnumerationKey))) &&
+                    ((this.ReliabilityEnumerationKey == null && other.ReliabilityEnumerationKey == null) ||
+                        (this.ReliabilityEnumerationKey != null &&
+                            this.ReliabilityEnumerationKey.Equals(other.ReliabilityEnumerationKey))));
+                if (areEqual)
+                {
+                    if (this.ArrayValue == null ^ other.ArrayValue == null)
+                    {
+                        return false;
+                    }
+                    else if (this.ArrayValue != null && other.ArrayValue != null)
+                    {
+                        for (int i = 0; i < this.ArrayValue.Length; i++)
+                        {
+                            if (!this.ArrayValue[i].Equals(other.ArrayValue[i]))
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+
+                return areEqual;
+            }
+            return false;
+        }
+
+        /// <summary></summary>
+        public override int GetHashCode()
+        {
+            var code = 13;
+            code = (code * 7) + Id.GetHashCode();
+            code = (code * 7) + Attribute.GetHashCode();
+            code = (code * 7) + NumericValue.GetHashCode();
+            code = (code * 7) + StringValueEnumerationKey.GetHashCode();
+            code = (code * 7) + BooleanValue.GetHashCode();
+            code = (code * 7) + PriorityEnumerationKey.GetHashCode();
+            code = (code * 7) + ReliabilityEnumerationKey.GetHashCode();
+            var arrCode = 13;
+            if (ArrayValue != null)
+            {
+                foreach (var item in ArrayValue)
+                {
+                    arrCode = (arrCode * 7) + item.GetHashCode();
+                }
+            }
+            return code + arrCode;
         }
     }
 }

--- a/MetasysServices/Models/VariantMultiple.cs
+++ b/MetasysServices/Models/VariantMultiple.cs
@@ -53,7 +53,15 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             var code = 13;
             code = (code * 7) + Id.GetHashCode();
-            code = (code * 7) + Variants.GetHashCode();
+            if (Variants != null)
+            {
+                var arrCode = 0;
+                foreach(var item in Variants)
+                {
+                    arrCode += item.GetHashCode();
+                }
+                code = (code * 7) + arrCode;
+            }
             return code;
         }
     }

--- a/MetasysServices/Models/VariantMultiple.cs
+++ b/MetasysServices/Models/VariantMultiple.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
@@ -19,6 +20,41 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             Id = id;
             Variants = variants;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whither this instance has values equal to a specified object.
+        /// </summary>
+        /// <param name="obj"></param>
+        public override bool Equals(object obj)
+        {
+            if (obj != null && obj is VariantMultiple)
+            {
+                var other = (VariantMultiple)obj;
+                bool areEqual = this.Id.Equals(other.Id);
+                if (areEqual)
+                {
+                    if (this.Variants == null ^ other.Variants == null)
+                    {
+                        return false;
+                    } 
+                    else if (this.Variants != null && other.Variants != null)
+                    {
+                        return Enumerable.SequenceEqual(this.Variants, other.Variants);
+                    }
+                }
+                return areEqual;                
+            }
+            return false;
+        }
+
+        /// <summary></summary>
+        public override int GetHashCode()
+        {
+            var code = 13;
+            code = (code * 7) + Id.GetHashCode();
+            code = (code * 7) + Variants.GetHashCode();
+            return code;
         }
     }
 }

--- a/MetasysServicesExampleApp/MetasysServicesExampleApp.csproj
+++ b/MetasysServicesExampleApp/MetasysServicesExampleApp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JohnsonControls.Metasys.BasicServices" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Flurl" Version="2.8.2" />
+    <PackageReference Include="Flurl.Http" Version="2.4.2" />
+  </ItemGroup>
+
+</Project>

--- a/MetasysServicesExampleApp/Program.cs
+++ b/MetasysServicesExampleApp/Program.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using JohnsonControls.Metasys.BasicServices;
+using Newtonsoft.Json;
+using System.Globalization;
+
+namespace MetasysServicesExampleApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                Console.WriteLine("Please enter in your credentials as arguments: username password hostname." +
+                    "\nRefer to the metasys-server/basic-services-dotnet README if you need help getting started.");
+                return;
+            }
+
+            var username = args[0];
+            var password = args[1];
+            var hostname = args[2];
+
+            #region Login
+
+            Console.WriteLine("Default culture is en_US. The culture for client translations can be changed in the code.");
+            // CultureInfo culture = new CultureInfo("en-US");
+
+            Console.WriteLine("\nLogging in...");
+            var client = new MetasysClient(hostname);
+            // var client = new MetasysClient(hostname, true); // Ignore Certificate Errors
+            // var client = new MetasysClient(hostname, false, ApiVersion.V2, culture);
+
+            var token = client.TryLogin(username, password);
+            Console.WriteLine($"Access token: {token.Token} expires {token.Expires}.");
+
+            #endregion
+
+            #region Refresh
+
+            Console.WriteLine("\nRefreshing Token...");
+            token = client.Refresh();
+            Console.WriteLine($"Access token: {token.Token} expires {token.Expires}.");
+
+            #endregion
+
+            Console.WriteLine("\nIndicate the object you want to run this example code on.");
+            Console.Write("Enter the fully qualified reference of the object (Example: \"site:device/itemReference\"): ");
+            string object1 = Console.ReadLine();
+
+            Console.WriteLine("\nIndicate the second object you want to run this example code on.");
+            Console.Write("Enter the fully qualified reference of the object: ");
+            string object2 = Console.ReadLine();
+
+            #region GetObjectIdentifier
+
+            Console.WriteLine("\n\nGetObjectIdentifier...");
+
+            // These variables are needed to run the other sections
+            Guid id1 = client.GetObjectIdentifier(object1).Value;
+            Console.WriteLine($"{object1} id: {id1}");
+
+            Guid id2 = client.GetObjectIdentifier(object2).Value;
+            Console.WriteLine($"{object2} id: {id2}");
+
+            List<Guid> ids = new List<Guid>() { id1, id2 };
+
+            #endregion
+
+            #region ReadProperty
+            
+            Console.WriteLine("\n\nReadProperty...");
+
+            Console.Write("\n!!!Please note ReadProperty will return null if the attribute does not exist, and will cause an exception in this example!!!");
+            Console.Write("\nEnter an attribute of the objects (Examples: name, description, presentValue): ");
+            string attribute1 = Console.ReadLine();
+
+            Console.Write("Enter a second attribute of the objects: ");
+            string attribute2 = Console.ReadLine();
+
+            List<string> attributes = new List<string>() { attribute1, attribute2 };
+
+            Console.WriteLine($"Get {attribute1} property...");
+
+            Variant result1Attr1 = client.ReadProperty(id1, attribute1).Value;
+            Variant result2Attr1  = client.ReadProperty(id2, attribute1).Value;
+
+            Console.WriteLine($"{result1Attr1.Id} {result1Attr1.Attribute} values (string, int, bool, reliability): " +
+                $"\n{result1Attr1.StringValue}, {result1Attr1.NumericValue}, {result1Attr1.BooleanValue}, {result1Attr1.Reliability}");
+            Console.WriteLine($"{result2Attr1.Id} {result2Attr1.Attribute} values (string, int, bool, reliability): " +
+                $"\n{result2Attr1.StringValue}, {result2Attr1.NumericValue}, {result2Attr1.BooleanValue}, {result2Attr1.Reliability}");
+
+            #endregion
+
+            #region ReadPropertyMultiple
+
+            Console.WriteLine("\n\nReadPropertyMultiple...");
+
+            Console.WriteLine($"\nGet {attribute1}, {attribute2} properties for each object...");
+            
+            IEnumerable<VariantMultiple> results = client.ReadPropertyMultiple(ids, attributes);
+
+            foreach (var varMultiple in results)
+            {
+                // Grab the list of Variants for each id
+                var variants = varMultiple.Variants;
+                foreach (var result in variants)
+                {
+                    Console.WriteLine($"{result.Id} {result.Attribute} values (string, int, bool, reliability): " +
+                        $"\n{result.StringValue}, {result.NumericValue},  {result.BooleanValue}, {result.Reliability}");
+                }
+            }
+
+            #endregion
+
+            #region WriteProperty Methods
+
+            Console.Write("\nEnter an attribute of the objects to change (don't worry, this will be reset to it's original value): ");
+            string attribute3 = Console.ReadLine();
+
+            Console.Write("\nEnter one new value for this attribute (this will be applied to both objects): ");
+            object change = Console.ReadLine();
+
+            // Get original values, this code will throw an exception if the 
+            Variant result1Attr3 = client.ReadProperty(id1, attribute3).Value;
+            Variant result2Attr3 = client.ReadProperty(id2, attribute3).Value;
+            Console.WriteLine($"{result1Attr3.Id} {result1Attr3.Attribute} original value: {result1Attr3.StringValue}");
+            Console.WriteLine($"{result2Attr3.Id} {result2Attr3.Attribute} original value: {result2Attr3.StringValue}");
+
+            Console.WriteLine("\nWriteProperty...");
+
+            // Change value
+            client.WriteProperty(id1, attribute3, change);
+            System.Threading.Thread.Sleep(3000);
+
+            // View changes
+            Variant result1Attr3Updated = client.ReadProperty(id1, attribute3).Value;
+            Console.WriteLine($"{result1Attr3Updated.Id} {result1Attr3Updated.Attribute} updated value: {result1Attr3Updated.StringValue}");
+
+            // Reset value
+            client.WriteProperty(id1, attribute3, result1Attr3.StringValue);
+            System.Threading.Thread.Sleep(3000);
+
+            Console.WriteLine("\nWrite Property Multiple...");
+
+            // Change value
+            List<(string, object)> attributes2 = new List<(string, object)>() { (attribute3, change) };
+            client.WritePropertyMultiple(ids, attributes2);
+            System.Threading.Thread.Sleep(3000);
+            
+            // View changes
+            Variant result1Attr3UpdatedM = client.ReadProperty(id1, attribute3).Value;
+            Variant result2Attr3UpdatedM = client.ReadProperty(id2, attribute3).Value;
+            Console.WriteLine($"{result1Attr3UpdatedM.Id} {result1Attr3UpdatedM.Attribute} updated value: {result1Attr3UpdatedM.StringValue}");
+            Console.WriteLine($"{result2Attr3UpdatedM.Id} {result2Attr3UpdatedM.Attribute} updated value: {result2Attr3UpdatedM.StringValue}");
+            System.Threading.Thread.Sleep(3000);
+            
+            // Reset Values
+            client.WriteProperty(id1, attribute3, result1Attr3.StringValue);
+            client.WriteProperty(id2, attribute3, result2Attr3.StringValue);
+
+            #endregion
+
+            #region Commands
+
+            Console.WriteLine("\n\nGetCommands...");
+
+            Console.WriteLine($"{id1} Commands:");
+            
+            IEnumerable<Command> commands = client.GetCommands(id1);
+
+            if (commands != null && commands.Count() > 0)
+            {
+                Console.WriteLine($"{commands.Count()}\n");
+                foreach(Command command in commands)
+                {
+                    Console.WriteLine($"{command.ToString()}\n");
+                }
+            }
+            else
+            {
+                Console.WriteLine("No commands found.");
+            }
+            
+
+            Console.WriteLine("\nSendCommand...");
+
+            Console.Write("\nPlease enter a commandId to execute: ");
+            string cmd = Console.ReadLine();
+
+            Console.WriteLine("\nEnter a number for a number type, enter the key for an enum type.");
+            Console.WriteLine("Please enter the values for the command in order followed by an empty line: ");
+            
+            List<object> list = new List<object>() { };
+            string option = "";
+            do
+            {
+                option = Console.ReadLine();
+                if (option != null && option.Length > 0) {
+                    list.Add(option);
+                }
+            } while (option != null && option.Length > 0);
+
+            Console.WriteLine("\nSending Command, please wait...");
+
+            client.SendCommand(id1, cmd, list);
+            System.Threading.Thread.Sleep(5000);
+
+            Console.WriteLine("Sent successfully.");
+
+            #endregion
+            #region GetNetworkDevices
+
+            Console.WriteLine("\n\nGetNetworkDevices...");
+            
+            IEnumerable<MetasysObjectType> types = client.GetNetworkDeviceTypes();
+            foreach (var type in types) {
+                Console.WriteLine($"\nAvailable Type {type.Id}: {type.Description}, {type.DescriptionEnumerationKey}");
+                string typeId = type.Id.ToString();
+                IEnumerable<MetasysObject> devices = client.GetNetworkDevices(typeId);
+                Console.WriteLine($"Devices found: {devices.Count()}");
+                Console.WriteLine($"First Device: {devices.ElementAt(0).Name}");
+            }
+
+            #endregion
+
+            #region GetObjects
+
+            Console.WriteLine("\n\nGet Objects..");
+
+            Console.WriteLine("\nPlease enter the depth of objects to retrieve for the first object.");
+            Console.Write("(1 = only this object, 2 = immediate children only): ");
+
+            int level = Convert.ToInt32(Console.ReadLine());
+            IEnumerable<MetasysObject> objects = client.GetObjects(id2, level);
+            MetasysObject obj = objects.ElementAt(0);
+
+            Console.WriteLine($"Parent object: {obj.Id}");
+
+            for (int i = 1; i < level; i++)
+            {
+                Console.WriteLine($"Child at level {i}: {obj.Id}");
+                if (objects.ElementAt(0).ChildrenCount > 0)
+                {
+                    obj = objects.ElementAt(0).Children.ElementAt(0);
+                }
+                else
+                {
+                    Console.WriteLine("This object has no children.");
+                }
+            }
+
+            #endregion
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ At any time you want to manually refresh the access token before it expires use 
 client.Refresh();
 ```
 
-To use the authorization token in an different HttpClient use the AccessToken object returned by these methods. A successful token will be in the form "Bearer ...".
+To use the authorization token in an different HttpClient use the AccessToken object returned by these methods or use the GetAccessToken method. A successful token will be in the form "Bearer ...".
 
 ```csharp
-AccessToken token = client.Refresh();
+AccessToken token = client.GetAccessToken();
 Console.WriteLine($"Token: {token.Token}\nExpires: {dateToDisplay.ToString("g", token.Expires)}");
 
 // Token: Bearer eyJ0eXAi...

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Finally, from the Developer Tab click the Visual Basic button to open the editor
 ## Usage (.NET)
 
 This section demonstrates how to use the MetasysClient to interact with your Metasys server from a .NET application.
-<!-- Download the sample project [here](https://github.com/metasys-server). -->
+There is an example on [Github](https://github.com/metasys-server/basic-services-dotnet/MetasysServicesExampleApp) that can be run from the command line.
 
 ### Creating a Client
 
@@ -143,7 +143,7 @@ Console.WriteLine($"Token: {token.Token}\nExpires: {dateToDisplay.ToString("g", 
 In order to use most of the methods in MetasysClient the id of the target object must be known. This id is in the form of a Guid and can be requested using the following given you know the item reference of the object:
 
 ```csharp
-Guid id = client.GetObjectIdentifier("siteName:naeName/Folder1.AV1");
+Guid id = client.GetObjectIdentifier("siteName:naeName/Folder1.AV1").Value;
 ```
 
 ### Get a Property
@@ -151,7 +151,7 @@ Guid id = client.GetObjectIdentifier("siteName:naeName/Folder1.AV1");
 In order to get a property you must know the Guid of the target object. An object called "Variant" is returned when getting a property from an object. Variant contains the property received in many different forms. There is a bit of intuition when handling a Variant since it will not explicitly provide the type of object received by the server. If the server cannot find the target object or attribute on the object this method will return a null value.
 
 ```csharp
-Variant result = client.ReadProperty(id, "presentValue");
+Variant result = client.ReadProperty(id, "presentValue").Value;
 string stringValue = result.StringValue;
 double numericValue = result.NumericValue;
 bool booleanValue = result.BooleanValue;


### PR DESCRIPTION
I created more tests and fixed any bugs I could find and added features. There is a small breaking change in this update for Command. The nuget package should be versioned accordingly.

Features added:
* Overrides .Equals and .GetHashCode methods for Models
* Additional Exceptions for Command and MetasysObject
* Updates to MetasysClient (see below)
* Changed Command Item to have nullable minimum and maximum as "null" could be returned by the database (Considered a breaking change)
* Fixed the automatic translations for Command Title
* Added example command line project

MetasysClient updates:
* ParseObjectIdentifier method added and refactored GetObjectIdentifier
* Removal of temporary client creation for GetWithFullUrl (#52)
* Modified GetObjects error handling to catch more exceptions
* Fixed error with GetNetworkDevices not passing type parameter

Testing Updates
* Implemented object comparison for tests (#38)
* Added more tests for edge cases
* Added tests for models and their new .Equals and .GetHashCode methods
* Fixed some errors in the README