### PR TITLE
Fix for issues of GUID and Async methods in Alarms

### DIFF
--- a/MetasysServices.Tests/Alarms/MetasysClientNetworkDeviceAlarmsTests.cs
+++ b/MetasysServices.Tests/Alarms/MetasysClientNetworkDeviceAlarmsTests.cs
@@ -27,7 +27,7 @@ namespace MetasysServices.Tests
             ""self"": ""https://win2016-vm2/api/v2/alarms?pageSize=100&excludePending=false&excludeAcknowledged=false&excludeDiscarded=false&page=1&sort=creationTime""
             ";
             httpTest.RespondWith(response);
-            var alarms = client.GetAlarmsForNetworkDevice(mockid.ToString(),new AlarmFilter { }); // No filter
+            var alarms = client.GetAlarmsForNetworkDevice(mockid,new AlarmFilter { }); // No filter
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -46,7 +46,7 @@ namespace MetasysServices.Tests
             ";
             httpTest.RespondWith(response);
 
-            var alarms = client.GetAlarmsForNetworkDevice(mockid.ToString(), AlarmFilter);
+            var alarms = client.GetAlarmsForNetworkDevice(mockid, AlarmFilter);
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -66,7 +66,7 @@ namespace MetasysServices.Tests
             ";
             httpTest
              .RespondWith(response);
-            var alarms = client.GetAlarmsForNetworkDevice(mockid.ToString(), AlarmFilter);
+            var alarms = client.GetAlarmsForNetworkDevice(mockid, AlarmFilter);
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -87,7 +87,7 @@ namespace MetasysServices.Tests
             ";
             httpTest.RespondWith(response);
 
-            var alarms = client.GetAlarmsForNetworkDevice(mockid.ToString(), new AlarmFilter { Type = 71 });
+            var alarms = client.GetAlarmsForNetworkDevice(mockid, new AlarmFilter { Type = 71 });
 
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
@@ -109,7 +109,7 @@ namespace MetasysServices.Tests
             ";
             httpTest.RespondWith(response);
 
-            Assert.Throws<MetasysObjectException>(()=>client.GetAlarmsForNetworkDevice(mockid.ToString(), new AlarmFilter { }));
+            Assert.Throws<MetasysObjectException>(()=>client.GetAlarmsForNetworkDevice(mockid, new AlarmFilter { }));
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);          
@@ -130,7 +130,7 @@ namespace MetasysServices.Tests
             ";
             httpTest.RespondWith(response);
             var e = Assert.Throws<MetasysObjectException>(() => // To do: Use Specific Exception for Alarm Item Provider
-                client.GetAlarmsForNetworkDevice(mockid.ToString(), new AlarmFilter()));
+                client.GetAlarmsForNetworkDevice(mockid, new AlarmFilter()));
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -143,7 +143,7 @@ namespace MetasysServices.Tests
             httpTest.RespondWith("Unauthorized", 401);
 
             var e = Assert.Throws<MetasysHttpException>(() =>
-                client.GetAlarmsForNetworkDevice(mockid.ToString(), new AlarmFilter { }));
+                client.GetAlarmsForNetworkDevice(mockid, new AlarmFilter { }));
 
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/networkDevices/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)

--- a/MetasysServices.Tests/Alarms/MetasysClientObjectAlarmsTests.cs
+++ b/MetasysServices.Tests/Alarms/MetasysClientObjectAlarmsTests.cs
@@ -27,7 +27,7 @@ namespace MetasysServices.Tests
             ""self"": ""https://win2016-vm2/api/v2/alarms?pageSize=100&excludePending=false&excludeAcknowledged=false&excludeDiscarded=false&page=1&sort=creationTime""
             ";
             httpTest.RespondWith(response);
-            var alarms = client.GetAlarmsForAnObject(mockid.ToString(),new AlarmFilter { }); // No filter
+            var alarms = client.GetAlarmsForAnObject(mockid,new AlarmFilter { }); // No filter
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -46,7 +46,7 @@ namespace MetasysServices.Tests
             ";
             httpTest.RespondWith(response);
 
-            var alarms = client.GetAlarmsForAnObject(mockid.ToString(), AlarmFilter);
+            var alarms = client.GetAlarmsForAnObject(mockid, AlarmFilter);
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -66,7 +66,7 @@ namespace MetasysServices.Tests
             ";
             httpTest
              .RespondWith(response);
-            var alarms = client.GetAlarmsForAnObject(mockid.ToString(), AlarmFilter);
+            var alarms = client.GetAlarmsForAnObject(mockid, AlarmFilter);
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
@@ -87,7 +87,7 @@ namespace MetasysServices.Tests
             ";
             httpTest.RespondWith(response);
 
-            var alarms = client.GetAlarmsForAnObject(mockid.ToString(), new AlarmFilter { Type = 71 });
+            var alarms = client.GetAlarmsForAnObject(mockid, new AlarmFilter { Type = 71 });
 
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
@@ -108,7 +108,7 @@ namespace MetasysServices.Tests
             ""self"": ""https://win2016-vm2/api/v2/alarms?pageSize=1&excludePending=false&excludeAcknowledged=false&excludeDiscarded=false&page=1&sort=creationTime""
             ";
             httpTest.RespondWith(response);
-            Assert.Throws<MetasysObjectException>(()=>client.GetAlarmsForAnObject(mockid.ToString(), new AlarmFilter { }));
+            Assert.Throws<MetasysObjectException>(()=>client.GetAlarmsForAnObject(mockid, new AlarmFilter { }));
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);          
@@ -130,7 +130,7 @@ namespace MetasysServices.Tests
             httpTest.RespondWith(response);
 
             var e = Assert.Throws<MetasysObjectException>(() => // To do: Use Specific Exception for Alarm Item Provider
-                client.GetAlarmsForAnObject(mockid.ToString(), new AlarmFilter { }));
+                client.GetAlarmsForAnObject(mockid, new AlarmFilter { }));
 
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
@@ -144,12 +144,12 @@ namespace MetasysServices.Tests
             httpTest.RespondWith("Unauthorized", 401);
 
             var e = Assert.Throws<MetasysHttpException>(() =>
-                client.GetAlarmsForAnObject(mockid.ToString(), new AlarmFilter { }));
+                client.GetAlarmsForAnObject(mockid, new AlarmFilter { }));
 
             httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/alarms")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
-            PrintMessage($"TestGetAlarmsUnauthorizedThrowsException: {e.Message}", true);    
+            PrintMessage($"TestGetAlarmsUnauthorizedThrowsException: {e.Message}", true);
         }
     }
 }

--- a/MetasysServices/Alarms/AlarmInfoProvider.cs
+++ b/MetasysServices/Alarms/AlarmInfoProvider.cs
@@ -34,27 +34,87 @@ namespace JohnsonControls.Metasys.BasicServices
                                                "FlurlClient can not be null.");
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Retrieves a collection of alarms.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm filter to get alarms.</param>
+        /// <returns>The list of alarms.</returns>
+        public PagedResult<List<AlarmItemProvider>> GetAlarms(AlarmFilter alarmFilter)
+        {
+            return GetAlarmsAsync(alarmFilter).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves a collection of alarms asynchronously.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm filter to get alarms.</param>
+        /// <returns>The list of alarms.</returns>
         public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsAsync(AlarmFilter filter)
         {                
             return await GetPagedResultsAsync<List<AlarmItemProvider>>("alarms", ToDictionary(filter));            
         }
 
-        /// <inheritdoc />
-        public async Task<AlarmItemProvider> GetSingleAlarmAsync(string alarmId)
+        /// <summary>
+        /// Retrieves the specified alarm.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The alarm details</returns>
+        public AlarmItemProvider GetSingleAlarm(Guid alarmId)
+        {
+            return GetSingleAlarmAsync(alarmId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves the specified alarm asynchronously.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The alarm details</returns>
+        public async Task<AlarmItemProvider> GetSingleAlarmAsync(Guid alarmId)
         {
             var response=await GetRequestAsync("alarms", null, alarmId);
             return JsonConvert.DeserializeObject<AlarmItemProvider>(response.ToString());
         }
 
-        /// <inheritdoc />
-        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForAnObjectAsync(string objectId, AlarmFilter filter)
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public PagedResult<List<AlarmItemProvider>> GetAlarmsForAnObject(Guid objectId, AlarmFilter alarmFilter)
+        {
+            return GetAlarmsForAnObjectAsync(objectId, alarmFilter).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForAnObjectAsync(Guid objectId, AlarmFilter filter)
         {
             return await GetPagedResultsAsync<List<AlarmItemProvider>>("objects", ToDictionary(filter), objectId, "alarms");
         }
 
-        /// <inheritdoc />
-        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForNetworkDeviceAsync(string networkDeviceId, AlarmFilter filter)
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified network device.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public PagedResult<List<AlarmItemProvider>> GetAlarmsForNetworkDevice(Guid networkDeviceId, AlarmFilter alarmFilter)
+        {
+           return GetAlarmsForNetworkDeviceAsync(networkDeviceId, alarmFilter).GetAwaiter().GetResult();
+        }
+
+       /// <summary>
+        /// Retrieves a collection of alarms for the specified network device.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForNetworkDeviceAsync(Guid networkDeviceId, AlarmFilter filter)
         {
             return await GetPagedResultsAsync<List<AlarmItemProvider>>("networkDevices", ToDictionary(filter), networkDeviceId, "alarms");
         }

--- a/MetasysServices/Alarms/Interfaces/IProvideAlarmInfo.cs
+++ b/MetasysServices/Alarms/Interfaces/IProvideAlarmInfo.cs
@@ -16,7 +16,21 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="alarmId">The identifier of the alarm.</param>
         /// <returns>The specified alarm details.</returns>
-        Task<AlarmItemProvider> GetSingleAlarmAsync(string alarmId);
+        AlarmItemProvider GetSingleAlarm(Guid alarmId);
+
+        /// <summary>
+        /// Retrieves the specified alarm asynchronously.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The specified alarm details.</returns>
+        Task<AlarmItemProvider> GetSingleAlarmAsync(Guid alarmId);
+
+        /// <summary>
+        /// Retrieves a collection of alarms.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm model to filter alarms.</param>
+        /// <returns>The list of alarms with details.</returns>
+        PagedResult<List<AlarmItemProvider>> GetAlarms(AlarmFilter alarmFilter);
 
         /// <summary>
         /// Retrieves a collection of alarms.
@@ -30,13 +44,27 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="objectId">The identifier of the object.</param>
         /// <returns>The list of alarms with details.</returns>
-        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForAnObjectAsync(string objectId, AlarmFilter alarmFilter);
+        PagedResult<List<AlarmItemProvider>> GetAlarmsForAnObject(Guid objectId, AlarmFilter alarmFilter);
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <returns>The list of alarms with details.</returns>
+        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForAnObjectAsync(Guid objectId, AlarmFilter alarmFilter);
 
         /// <summary>
         /// Retrieves a collection of alarms for the specified object.
         /// </summary>
         /// <param name="networkDeviceId">The identifier of the network device.</param>
         /// <returns>The list of alarms with details.</returns>
-        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForNetworkDeviceAsync(string networkDeviceId, AlarmFilter alarmFilter);
+        PagedResult<List<AlarmItemProvider>> GetAlarmsForNetworkDevice(Guid networkDeviceId, AlarmFilter alarmFilter);
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <returns>The list of alarms with details.</returns>
+        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForNetworkDeviceAsync(Guid networkDeviceId, AlarmFilter alarmFilter);
     }
 }

--- a/MetasysServices/Interfaces/IMetasysClient.cs
+++ b/MetasysServices/Interfaces/IMetasysClient.cs
@@ -206,7 +206,14 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="alarmId">The identifier of the alarm.</param>
         /// <returns>The alarm details</returns>
-        AlarmItemProvider GetSingleAlarm(string alarmId);
+        AlarmItemProvider GetSingleAlarm(Guid alarmId);
+		
+	    /// <summary>
+        /// Retrieves the specified alarm asynchronously.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The alarm details</returns>
+        Task<AlarmItemProvider> GetSingleAlarmAsync(Guid alarmId);
 
         /// <summary>
         /// Retrieves a collection of alarms.
@@ -214,6 +221,13 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="alarmFilter">The alarm filter to get alarms.</param>
         /// <returns>The list of alarms.</returns>
         PagedResult<List<AlarmItemProvider>> GetAlarms(AlarmFilter alarmFilter);
+		
+		/// <summary>
+        /// Retrieves a collection of alarms asynchronously.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm filter to get alarms.</param>
+        /// <returns>The list of alarms.</returns>
+        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsAsync(AlarmFilter alarmFilter);
 
         /// <summary>
         /// Retrieves a collection of alarms for the specified object.
@@ -221,15 +235,31 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="objectId">The identifier of the object.</param>
         /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
         /// <returns>The list of alarms for the specified object.</returns>
-        PagedResult<List<AlarmItemProvider>> GetAlarmsForAnObject(string objectId, AlarmFilter alarmFilter);
+        PagedResult<List<AlarmItemProvider>> GetAlarmsForAnObject(Guid objectId, AlarmFilter alarmFilter);
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object asynchronously.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForAnObjectAsync(Guid objectId, AlarmFilter alarmFilter);
 
         /// <summary>
         /// Retrieves a collection of alarms for the specified network device.
         /// </summary>
         /// <param name="networkDeviceId">The identifier of the network device.</param>
-        /// <param name=""alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
         /// <returns>The list of alarms for the specified object.</returns>
-        PagedResult<List<AlarmItemProvider>> GetAlarmsForNetworkDevice(string networkDeviceId, AlarmFilter alarmFilter);
+        PagedResult<List<AlarmItemProvider>> GetAlarmsForNetworkDevice(Guid networkDeviceId, AlarmFilter alarmFilter);
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified network device asynchronously.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForNetworkDeviceAsync(Guid networkDeviceId, AlarmFilter alarmFilter);		
 
         /// <summary>
         /// Retrieves a collection of attributes under the specified object for which samples are available.

--- a/MetasysServices/MetasysClient.cs
+++ b/MetasysServices/MetasysClient.cs
@@ -1128,28 +1128,86 @@ namespace JohnsonControls.Metasys.BasicServices
             return toMetasysObject(objects);
         }
 		
-        /// <inheritdoc />
-        public AlarmItemProvider GetSingleAlarm(string alarmId)
+        /// <summary>
+        /// Retrieves the specified alarm.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The alarm details</returns>
+        public AlarmItemProvider GetSingleAlarm(Guid alarmId)
         {
             return alarmInfoProvider.GetSingleAlarmAsync(alarmId).GetAwaiter().GetResult();
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Retrieves the specified alarm asynchronously.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The specified alarm details.</returns>
+        public async Task<AlarmItemProvider> GetSingleAlarmAsync(Guid alarmId)
+        {
+            return await alarmInfoProvider.GetSingleAlarmAsync(alarmId);
+        }
+
+        /// <summary>
+        /// Retrieves a collection of alarms.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm filter to get alarms.</param>
+        /// <returns>The list of alarms.</returns>
         public PagedResult<List<AlarmItemProvider>> GetAlarms(AlarmFilter alarmFilter)
         {
             return alarmInfoProvider.GetAlarmsAsync(alarmFilter).GetAwaiter().GetResult();
         }
 
-        /// <inheritdoc />
-        public PagedResult<List<AlarmItemProvider>> GetAlarmsForAnObject(string objectId, AlarmFilter alarmFilter)
+        /// <summary>
+        /// Retrieves a collection of alarms asynchronously.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm model to filter alarms.</param>
+        /// <returns>The list of alarms with details.</returns>
+        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsAsync(AlarmFilter alarmFilter)
+        {
+            return await alarmInfoProvider.GetAlarmsAsync(alarmFilter);
+        }
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public PagedResult<List<AlarmItemProvider>> GetAlarmsForAnObject(Guid objectId, AlarmFilter alarmFilter)
         {
             return alarmInfoProvider.GetAlarmsForAnObjectAsync(objectId, alarmFilter).GetAwaiter().GetResult();
         }
 
-        /// <inheritdoc />
-        public PagedResult<List<AlarmItemProvider>> GetAlarmsForNetworkDevice(string networkDeviceId, AlarmFilter alarmFilter)
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object asynchronously.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <returns>The list of alarms with details.</returns>
+        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForAnObjectAsync(Guid objectId, AlarmFilter alarmFilter)
+        {
+            return await alarmInfoProvider.GetAlarmsForAnObjectAsync(objectId, alarmFilter);
+        }
+
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified network device.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public PagedResult<List<AlarmItemProvider>> GetAlarmsForNetworkDevice(Guid networkDeviceId, AlarmFilter alarmFilter)
         {
             return alarmInfoProvider.GetAlarmsForNetworkDeviceAsync(networkDeviceId, alarmFilter).GetAwaiter().GetResult();
+        }
+
+	    /// <summary>
+        /// Retrieves a collection of alarms for the specified object asynchronously.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <returns>The list of alarms with details.</returns>
+        public async Task<PagedResult<List<AlarmItemProvider>>> GetAlarmsForNetworkDeviceAsync(Guid networkDeviceId, AlarmFilter alarmFilter)
+        {
+            return await alarmInfoProvider.GetAlarmsForNetworkDeviceAsync(networkDeviceId, alarmFilter);
         }
 
         /// <inheritdoc />

--- a/MetasysServicesCom/Interfaces/ILegacyMetasysClient.cs
+++ b/MetasysServicesCom/Interfaces/ILegacyMetasysClient.cs
@@ -88,7 +88,7 @@ namespace JohnsonControls.Metasys.ComServices
         /// </summary>
         /// <param name="alarmId">The identifier of the alarm.</param>
         /// <returns>The specified alarm details.</returns>
-        object GetSingleAlarm(string alarmId);
+        object GetSingleAlarm(Guid alarmId);
 
         /// <summary>
         /// Retrieves a collection of alarms.
@@ -103,7 +103,7 @@ namespace JohnsonControls.Metasys.ComServices
         /// <param name="objectId">The identifier of the object.</param>
         /// <param name="alarmFilter">The alarm model to filter alarms.</param>
         /// <returns>The list of alarms for the specified object.</returns>
-        object GetAlarmsForAnObject(string objectId, dynamic alarmFilter);
+        object GetAlarmsForAnObject(Guid objectId, dynamic alarmFilter);
 
         /// <summary>
         /// Retrieves a collection of alarms for the specified object.
@@ -111,7 +111,7 @@ namespace JohnsonControls.Metasys.ComServices
         /// <param name="networkDeviceId">The identifier of the network device.</param>
         /// <param name="alarmFilter">The alarm model to filter alarms.</param>
         /// <returns>The list of alarms for the specified object.</returns>
-        object GetAlarmsForNetworkDevice(string networkDeviceId, dynamic alarmFilter);
+        object GetAlarmsForNetworkDevice(Guid networkDeviceId, dynamic alarmFilter);
 
         /// <summary>
         /// Retrieves a collection of attributes under the specified object for which samples are available.

--- a/MetasysServicesCom/LegacyMetasysClient.cs
+++ b/MetasysServicesCom/LegacyMetasysClient.cs
@@ -277,14 +277,22 @@ namespace JohnsonControls.Metasys.ComServices
             return Mapper.Map<IComMetasysObject[]>(res);
         }
 
-        /// <inheritdoc />
-        public object GetSingleAlarm(string alarmId)
+        /// <summary>
+        /// Retrieves the specified alarm.
+        /// </summary>
+        /// <param name="alarmId">The identifier of the alarm.</param>
+        /// <returns>The alarm details</returns>
+        public object GetSingleAlarm(Guid alarmId)
         {
             var alarmItem = Client.GetSingleAlarm(alarmId);
             return Mapper.Map<IComProvideAlarmItem>(alarmItem);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Retrieves a collection of alarms.
+        /// </summary>
+        /// <param name="alarmFilter">The alarm filter to get alarms.</param>
+        /// <returns>The list of alarms.</returns>
         public object GetAlarms(dynamic alarmFilter)
         {
             var mapAlarmFilter = Mapper.Map<AlarmFilter>(alarmFilter);
@@ -292,16 +300,26 @@ namespace JohnsonControls.Metasys.ComServices
             return Mapper.Map<IComPagedResult<IComProvideAlarmItem>>(alarmItems);
         }
 
-        /// <inheritdoc />
-        public object GetAlarmsForAnObject(string objectId, dynamic alarmFilter)
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified object.
+        /// </summary>
+        /// <param name="objectId">The identifier of the object.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public object GetAlarmsForAnObject(Guid objectId, dynamic alarmFilter)
         {
             var mapAlarmFilterForAnObject = Mapper.Map<AlarmFilter>(alarmFilter);
             var alarmItems = Client.GetAlarmsForAnObject(objectId, mapAlarmFilterForAnObject);
             return Mapper.Map<IComProvideAlarmItem[]>(alarmItems);
         }
 
-        /// <inheritdoc />
-        public object GetAlarmsForNetworkDevice(string networkDeviceId, dynamic alarmFilter)
+        /// <summary>
+        /// Retrieves a collection of alarms for the specified network device.
+        /// </summary>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
+        /// <param name="alarmFilter">TThe alarm filter to get alarms.</param>
+        /// <returns>The list of alarms for the specified object.</returns>
+        public object GetAlarmsForNetworkDevice(Guid networkDeviceId, dynamic alarmFilter)
         {
             var mapAlarmFilterForObject = Mapper.Map<AlarmFilter>(alarmFilter);
             var alarmItems = Client.GetAlarms(mapAlarmFilterForObject);

--- a/MetasysServicesComExampleApp/Program.cs
+++ b/MetasysServicesComExampleApp/Program.cs
@@ -239,7 +239,7 @@ namespace MetasysServicesComExampleApp
             #region Alarms
 
             Console.WriteLine("Enter alarm id to get alarm details: ");
-            string alarmId = Console.ReadLine();
+            Guid alarmId = Guid.Parse(Console.ReadLine());
 
             dynamic alarmItem = legacyClient.GetSingleAlarm(alarmId);
 
@@ -294,7 +294,7 @@ namespace MetasysServicesComExampleApp
 
             Console.WriteLine(string.Format("\nAlarm details found for this object {0}", objectId));
 
-            dynamic alarmItemsForObject = legacyClient.GetAlarmsForAnObject(objectId, alarmFilterForObject);
+            dynamic alarmItemsForObject = legacyClient.GetAlarmsForAnObject(Guid.Parse(objectId), alarmFilterForObject);
 
             Console.WriteLine("\nEnter network device id to get alarm details: ");
             string networkDeviceId = Console.ReadLine();
@@ -315,7 +315,7 @@ namespace MetasysServicesComExampleApp
 
             Console.WriteLine(string.Format("\nAlarm details found for the network device {0}", networkDeviceId));
 
-            dynamic alarmItemsForNetworkDevice = legacyClient.GetAlarmsForNetworkDevice(objectId, alarmFilterModelForNetworkDevice);
+            dynamic alarmItemsForNetworkDevice = legacyClient.GetAlarmsForNetworkDevice(Guid.Parse(objectId), alarmFilterModelForNetworkDevice);
 
             #endregion
 

--- a/MetasysServicesExampleApp/FeaturesDemo/AlarmsDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/AlarmsDemo.cs
@@ -18,7 +18,7 @@ namespace MetasysServicesExampleApp.FeaturesDemo
             #region Alarms
 
             Console.WriteLine("Enter alarm id to get alarm details: ");
-            string alarmId = Console.ReadLine();
+            Guid alarmId = Guid.Parse(Console.ReadLine());
 
             AlarmItemProvider alarmItem = client.GetSingleAlarm(alarmId);
 
@@ -72,7 +72,7 @@ namespace MetasysServicesExampleApp.FeaturesDemo
 
             Console.WriteLine(string.Format("\nAlarm details found for this object {0}", objectId));
 
-            var alarmItemsForObject = client.GetAlarmsForAnObject(objectId, alarmFilterForObject);
+            var alarmItemsForObject = client.GetAlarmsForAnObject(Guid.Parse(objectId), alarmFilterForObject);
 
             Console.WriteLine("\nEnter network device id to get alarm details: ");
             string networkDeviceId = Console.ReadLine();
@@ -92,7 +92,7 @@ namespace MetasysServicesExampleApp.FeaturesDemo
 
                 Console.WriteLine(string.Format("\nAlarm details found for this object {0}", objectId));
 
-                var alarmItemsForNetworkDevice = client.GetAlarmsForNetworkDevice(networkDeviceId, alarmFilterModelForNetworkDevice);
+                var alarmItemsForNetworkDevice = client.GetAlarmsForNetworkDevice(Guid.Parse(networkDeviceId), alarmFilterModelForNetworkDevice);
             }
             else
             {


### PR DESCRIPTION
This PR resolves following issues:

| Task Number                               |Description|
|---------------------------------------------------------------------------------|------|
| [Issue Number 74](https://github.com/metasys-server/basic-services-dotnet/issues/74) |Alarms methods should be exposed in both sync and async version|
| [Issue Number 75](https://github.com/metasys-server/basic-services-dotnet/issues/75) |Get Alarms methods should take GUID object instead of the string|
| [Issue Number 76](https://github.com/metasys-server/basic-services-dotnet/issues/76) |Legacy client methods should have Guid as string|

### Check out this Pull Request Locally
```
git fetch upstream pull/77/head:FixIssues
```