### PR TITLE
Update default value for PageSize

### DIFF
--- a/MetasysServices/BasicServiceProvider.cs
+++ b/MetasysServices/BasicServiceProvider.cs
@@ -558,8 +558,10 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             bool hasNext = true;
             List<JToken> aggregatedResponse = new List<JToken>();
-            
+
             int page = 1;
+            int pageSize = 1000;
+
             // Init our dictionary for paging
             if (parameters == null)
             {
@@ -569,11 +571,16 @@ namespace JohnsonControls.Metasys.BasicServices
             {
                 parameters.Add("page", page.ToString());
             }
+            if (!parameters.ContainsKey("pageSize"))
+            {
+                parameters.Add("pageSize", pageSize.ToString());
+            }
             while (hasNext)
             {
                 hasNext = false;
                 // Just overwrite page parameter
                 parameters["page"] = page.ToString();
+                parameters["pageSize"] = pageSize.ToString();
                 var response = await GetPagedResultsAsync<JToken>(resource, parameters, pathSegments).ConfigureAwait(false);
                 var total = response.Total;
                 if (total > 0)


### PR DESCRIPTION
### Background:- 
- There is a bug [PTL-5638](https://jciproducts.atlassian.net/browse/PTL-5638) in the PVT application, where PVT is taking a very long time to get the MUI data for a huge Metasys Site.
for example, Getting all Equipment calls takes approx 40-50 mins (where equipment count is approx 8500).

This PR contains a fix, where increasing the PageSize to 1000 (from 100) has improved the performance. for example, now getting Equipment data from the same call takes approx. 15 mins.

### Help Needed:- 
- Could increasing the PageSize to 1000 impact any other API calls?
- Any suggestion for other ways to increase the performance of the API calls?
- There is another method in BasicServiceProvider named [ToMetasysObject](https://github.com/metasys-server/basic-services-dotnet/blob/015d41d94e8e8c3ba133a2e88d9d9b178d953af3/MetasysServices/BasicServiceProvider.cs#L130-L139) which also takes times to parse the JSON response into MetasysObject. I am not sure if that method could also be improved further to increase performance. Could you please take a look at this method as well?


@Federico-Artioli @michaelgwelch

 
